### PR TITLE
Make test_sampling pass

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -87,7 +87,7 @@ def test_mesh_hmc():
 
     hmc.run(10)
 
-    assert np.linalg.norm(hmc.x - ref_hmc) < 1.0e-14
+    assert np.allclose(hmc.x,ref_hmc)
 
 @pytest.fixture(params=["flip_parallel", "flip_serial"])
 def flip_type(request):


### PR DESCRIPTION
This test does not pass on my machine (osx-arm64). But if I use the normal way of checking numerical equivalence from numpy, it passes.
Line here https://github.com/bio-phys/trimem/blob/981c1f100b1b089563665f9077837386b1ad0bb3/tests/test_sampling.py#L90