### PR TITLE
Fix use of deprecated scipy.minimize api.

### DIFF
--- a/src/trimem/mc/util.py
+++ b/src/trimem/mc/util.py
@@ -289,7 +289,7 @@ def run_minim(mesh, estore, config):
     }
     res = minimize(
         funcs.fun,
-        mesh.x,
+        mesh.x.ravel(),
         jac=funcs.grad,
         callback=_cb,
         method="L-BFGS-B",


### PR DESCRIPTION
For scipy>=1.11 x0 must be passed as ndim=1 array. Implicit raveling of the array was deprecated with 1.11.